### PR TITLE
Adding clarification for Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,8 @@ Otterbrass is a MS Teams bot that distribute workitems load among suscribed memb
   - dist\index.js
   - package.json
   - package-lock.json
-- Copy the `node_modules` folder to your wwwroot folder, or run `npm install` into your server console (in the wwwroot) folder.
+- Copy the `node_modules` folder to your wwwroot folder, or run `npm install` into your server console (in the wwwroot) folder. More on why in [here](https://github.com/liady/webpack-node-externals)
+
 - Restart your server.
 - Deploy your bot to teams channel using the following instructions:
   - [Create an app package for your Microsoft Teams app](https://docs.microsoft.com/en-us/microsoftteams/platform/concepts/build-and-test/apps-package#creating-a-manifest)


### PR DESCRIPTION
Adding clarification on why we are using webpack node-externals:

```
From:
https://github.com/liady/webpack-node-externals
```

```
Why is not bundling node_modules a good thing?
When writing a node library, for instance, you may want to split your code to several files, and use Webpack to bundle them. However - you wouldn't want to bundle your code with its entire node_modules dependencies, for two reasons:

It will bloat your library on npm.
It goes against the entire npm dependencies management. If you're using Lodash, and the consumer of your library also has the same Lodash dependency, npm makes sure that it will be added only once. But bundling Lodash in your library will actually make it included twice, since npm is no longer managing this dependency.
```