### PR TITLE
Replying to get request

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -30,7 +30,7 @@
                 "typescript": "4.4.3",
                 "webpack": "5.52.1",
                 "webpack-cli": "4.8.0",
-                "webpack-node-externals": "^3.0.0"
+                "webpack-node-externals": "3.0.0"
             }
         },
         "node_modules/@azure/abort-controller": {

--- a/src/index.ts
+++ b/src/index.ts
@@ -66,6 +66,14 @@ server.post('/api/messages', (req, res) => {
     });
 });
 
+// [OPTIONAL]
+// When deploying azure usually pings the web app server to know the status. The request can be ignored or answered, depending
+// on the implementation. In my case it was logging the errors so I prefer to just reply to the request.
+server.get('/', (req, res, next) => {
+    res.send(200);
+    next();
+});
+
 // Listen for Upgrade requests for Streaming.
 server.on('upgrade', (req, socket, head) => {
     // Create an adapter scoped to this WebSocket connection to allow storing session data.

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -16,6 +16,7 @@ const config = (env, argv) => {
             // Add '.ts' and '.tsx' as resolvable extensions.
             extensions: [".ts", ".tsx", ".js", ".json"]
         },
+        externalsPresets: { node: true }, // in order to ignore built-in modules like path, fs, etc. (https://github.com/liady/webpack-node-externals)
         externals: [nodeExternals()], // in order to ignore all modules in node_modules folder
 
         module: {


### PR DESCRIPTION
Otterbrass server was ignoring get requests, but because Azure uses it to know the service state it was creating false alerts. So, I'm replying with 200 to any request.