### PR TITLE
fix remove_User, removeUserOOF stored procedures

### DIFF
--- a/deploymentScripts/DbScripts/v1.5/Version.sql
+++ b/deploymentScripts/DbScripts/v1.5/Version.sql
@@ -1,0 +1,11 @@
+﻿DECLARE @versionTable TABLE (Internal_id  INT);
+
+INSERT INTO @versionTable
+SELECT Internal_Id
+FROM [Version]
+
+UPDATE [Version]
+SET [Version] = 1.5
+WHERE [Internal_Id] IN
+    (SELECT [Internal_Id]
+    FROM @versionTable);

--- a/deploymentScripts/DbScripts/v1.5/usp_RemoveUser.sql
+++ b/deploymentScripts/DbScripts/v1.5/usp_RemoveUser.sql
@@ -1,0 +1,166 @@
+﻿ALTER PROCEDURE usp_RemoveUser
+    @channelId          NVARCHAR(255),   
+    @channelName        NVARCHAR(255),
+    @userId             NVARCHAR(255),
+    @userName           NVARCHAR(255)   
+AS   
+    SET NOCOUNT ON;  
+
+    BEGIN TRANSACTION
+
+    DECLARE @channelInternalTable TABLE (internal_id   INT);
+    DECLARE @channelInternalIdCount INT;
+    DECLARE @channelInternalId INT;
+
+    -- GET THE CHANNEL INTERNAL ID
+
+    SELECT @channelInternalIdCount = COUNT(Internal_id)
+    FROM  [Channels]
+    WHERE [Id] = @channelId
+
+    IF @channelInternalIdCount < 1
+    BEGIN
+       RAISERROR ('Error, channel has not been added', 
+               16, -- Severity
+               1 -- State
+               );  
+    END
+    ELSE
+    BEGIN
+        INSERT INTO @channelInternalTable(Internal_id)
+            SELECT TOP(1)Internal_id
+            FROM  [Channels]
+            WHERE [Id] = @channelId 
+    END
+
+    IF @@ERROR <> 0
+    BEGIN
+        -- Rollback the transaction
+        ROLLBACK
+
+        -- Raise an error and return
+        RAISERROR ('Error, channel has not been added', 16, 1)
+        RETURN
+    END
+
+    SELECT TOP(1) @channelInternalId =  Internal_id
+    FROM  @channelInternalTable
+
+
+    -- GET THE USER INTERNAL ID
+    DECLARE @userInternalIdTable TABLE (internal_id   INT);
+    DECLARE @userInternalIdCount INT;
+    DECLARE @userInternalId INT;
+
+    SELECT @userInternalIdCount = COUNT(cobu.User_internal_id)
+    FROM[Channels] c
+    INNER JOIN [ChannelsOtterBrassUser] cobu
+    ON c.Internal_id = cobu.Channel_internal_id
+    INNER JOIN [OtterBrassUser] obu
+    ON cobu.User_Internal_id = obu.Internal_Id
+    WHERE c.id = @channelId
+    AND obu.id = @userId
+
+    IF @userInternalIdCount < 1
+    BEGIN
+        RAISERROR ('Error, user has not been added', 16, 1)
+    END
+    ELSE
+    BEGIN
+        INSERT INTO @userInternalIdTable(Internal_id)
+            SELECT TOP(1) obu.Internal_id
+            FROM[Channels] c
+            INNER JOIN [ChannelsOtterBrassUser] cobu
+            ON c.Internal_id = cobu.Channel_internal_id
+            INNER JOIN [OtterBrassUser] obu
+            ON cobu.User_Internal_id = obu.Internal_Id
+            WHERE c.id = @channelId
+            AND obu.id = @userId
+    END
+
+    IF @@ERROR <> 0
+    BEGIN
+        -- Rollback the transaction
+        ROLLBACK
+
+        -- Raise an error and return
+        RAISERROR ('Error, user has not been added', 16, 1)
+        RETURN
+    END
+
+    SELECT TOP(1) @userInternalId =  Internal_id
+    FROM  @userInternalIdTable
+
+    -- REMOVING THE USER-CHANNEL RELATION
+    DECLARE @userChannelsInternalTable TABLE (Internal_id  INT);
+    DECLARE @userChannelsInternalIdCount INT;
+    DECLARE @userChannelsInternalId INT;
+    DECLARE @totalNumberOfChannelsAdded INT;
+
+    SELECT @userChannelsInternalIdCount = COUNT(Internal_id)
+    FROM [ChannelsOtterBrassUser]
+    WHERE [User_internal_id] = @userInternalId
+    AND   [Channel_internal_id] = @channelInternalId
+
+    IF @userChannelsInternalIdCount < 1
+    BEGIN
+        RAISERROR ('Error, specified user has not been added on that channel', 16, 1)
+    END
+    ELSE
+    BEGIN
+
+    INSERT INTO @userChannelsInternalTable(Internal_id)
+          SELECT TOP(1) Internal_id
+          FROM [ChannelsOtterBrassUser]
+          WHERE [User_internal_id] = @userInternalId
+          AND   [Channel_internal_id] = @channelInternalId
+
+      EXEC usp_RemoveUserRandom @channelId,@userId
+      EXEC usp_RemoveUserOof @channelId,@userId
+
+      DELETE FROM [UserRanking]
+      WHERE [ChannelsOtterBrassUser_internalId] IN 
+      (SELECT [Internal_id]
+       FROM @userChannelsInternalTable);
+      
+      ALTER TABLE [ChannelsOtterBrassUser] 
+      DROP CONSTRAINT FK_OtterBrassUser;
+      
+      ALTER TABLE [ChannelsOtterBrassUser] 
+      DROP CONSTRAINT FK_Channel;
+      
+      DELETE FROM [ChannelsOtterBrassUser]
+      WHERE [User_internal_id] = @userInternalId
+      AND   [Channel_internal_id] = @channelInternalId
+
+      -- If it is the only/last channel were user exist also drop it from the user table
+      SELECT @totalNumberOfChannelsAdded = COUNT(Internal_id)
+      FROM [ChannelsOtterBrassUser]
+      WHERE [User_internal_id] = @userInternalId
+
+      IF @totalNumberOfChannelsAdded < 1
+      BEGIN
+        DELETE FROM [OtterBrassUser]
+        WHERE [Id] = @userId
+        AND   [Name] = @userName
+      END
+
+      ALTER TABLE [ChannelsOtterBrassUser] ADD CONSTRAINT FK_OtterBrassUser FOREIGN KEY (User_internal_id) REFERENCES OtterBrassUser(Internal_id);
+      ALTER TABLE [ChannelsOtterBrassUser] ADD CONSTRAINT FK_Channel FOREIGN KEY (Channel_internal_id) REFERENCES Channels(Internal_id);
+
+    END
+
+    IF @@ERROR <> 0
+    BEGIN
+        -- Rollback the transaction
+        ROLLBACK
+
+        -- Raise an error and return
+        RAISERROR ('Error in while deleting the user.', 16, 1)
+        RETURN
+    END
+    
+    
+
+    COMMIT
+GO

--- a/deploymentScripts/DbScripts/v1.5/usp_RemoveUserOof.sql
+++ b/deploymentScripts/DbScripts/v1.5/usp_RemoveUserOof.sql
@@ -1,0 +1,68 @@
+﻿ALTER PROCEDURE usp_RemoveUserOof
+    @channelId          NVARCHAR(255),
+    @userId             NVARCHAR (255)
+
+AS   
+    SET NOCOUNT ON;  
+
+    BEGIN TRANSACTION
+
+        DECLARE @userFound         INT;
+        DECLARE @removeUser        INT;
+        DECLARE @otcuInternalTable TABLE (Internal_id INT);
+        DECLARE @cobuoofInternalTable TABLE (Internal_id INT);
+
+        SET @userFound = 0;
+
+        -- Verify if the users exist on the db and in the right channel.
+        INSERT INTO @otcuInternalTable
+            SELECT otcu.Internal_id
+            FROM ChannelsOtterBrassUser otcu
+            INNER JOIN OtterBrassUser otus
+            ON otus.Internal_id = otcu.User_internal_id
+            INNER JOIN Channels otch
+            ON otch.Internal_id = otcu.Channel_internal_id
+            WHERE otus.Id = @userId
+            AND otch.Id = @channelId
+
+        SELECT @userFound = COUNT(Internal_id)
+        FROM @otcuInternalTable
+
+        -- User should be registered before continuing
+        IF @userFound < 1
+        BEGIN
+            ROLLBACK
+            RETURN;
+        END
+
+        -- Verify if the users exist on the oof table
+        INSERT INTO @cobuoofInternalTable
+        SELECT otcuInternal.Internal_id
+        FROM @otcuInternalTable otcuInternal
+        INNER JOIN ChannelsOtterBrassUserOOF cobuoof
+        ON cobuoof.ChannelsOtterBrassUser_internal_id = otcuInternal.Internal_id
+
+        SELECT @removeUser = COUNT(Internal_id)
+        FROM @cobuoofInternalTable
+
+        -- If user is not found in the OOF Table it means he has never used the feature
+        IF @removeUser > 0
+        BEGIN
+            SELECT TOP 1 @removeUser = Internal_id
+            FROM @cobuoofInternalTable
+
+            DELETE FROM [ChannelsOtterBrassUserOOF]
+            WHERE ChannelsOtterBrassUser_internal_id = @removeUser
+        END
+
+         IF @@ERROR <> 0
+         BEGIN
+            -- Rollback the transaction
+            ROLLBACK
+
+            -- Raise an error and return
+            RAISERROR ('Error while updating Random Table status.', 16, 1)
+            RETURN
+         END
+    COMMIT
+GO

--- a/src/Common/AppInsights.ts
+++ b/src/Common/AppInsights.ts
@@ -5,14 +5,12 @@ export class AppInsights {
     private client;
 
     private constructor() {
-        /* Used for debugging purposes, we don't want to send debug information to appInsights. */
-        if (!process.env.skipTelemetry) {
-            appInsights.setup(process.env.AppInsightsInstrumentationKey).start();
-        } else {
-            appInsights = new MockAppInsights();
-        }
-
+        appInsights.setup(process.env.AppInsightsInstrumentationKey).start();
         this.client = appInsights.defaultClient;
+        /* Used for debugging purposes, we don't want to send debug information to appInsights. */
+        if (process.env.skipTelemetry) {
+            appInsights.defaultClient.config.disableAppInsights = true
+        }
     }
 
     static get instance(): AppInsights {
@@ -28,19 +26,6 @@ export class AppInsights {
     }
 
     public logTrace(msg: string) {
-        this.client.trackTrace(msg);
-    }
-}
-
-/**
- * Used for debugging purposes, we don't want to send debug information to appInsights.
- */
-class MockAppInsights {
-    public defaultClient;
-    public constructor() {
-        this.defaultClient = {
-            trackException: (exception: any) => console.log(JSON.stringify(exception)),
-            trackTrace: (exception: any) => console.log(JSON.stringify(exception)),
-        }
+        this.client.trackTrace({message: msg});
     }
 }

--- a/src/Controllers/CommonMessageController.ts
+++ b/src/Controllers/CommonMessageController.ts
@@ -9,7 +9,6 @@ import { BotMessages } from '../Common/BotMessage';
 import { EnumShirtSize } from '../Enums/EnumShirtSize';
 import { ReviewDao } from '../Dao/ReviewDao';
 import { Constants } from '../Common/Constants';
-import { AppInsights } from '../Common/AppInsights';
 
 export class CommonMessagesController {
     private static _myLazyController: CommonMessagesController;
@@ -67,12 +66,12 @@ export class CommonMessagesController {
                 users = new Array<User>();
             }
 
-            // TODO: verify this logic as it changed when migrated.
-            users = { ...users, ...tempList };
+            users = [ ...users, ...tempList ];
         }
 
         let replyMsg = '';
         if (users) {
+            const addUserArray = [];
             for (const user of users) {
                 if (!user) {
                     continue;
@@ -86,14 +85,10 @@ export class CommonMessagesController {
                 replyMsg += user.name + ', ';
                 user.userChannel = channel;
                 const userDao = new UserDao();
-                try{
-                    // TODO: Move this to a promise array and complete using Promise.all.
-                    await userDao.addUser(user);
-                } catch(error) {
-                    AppInsights.instance.logException(JSON.stringify(error));
-                }
-
+                addUserArray.push(userDao.addUser(user))
             }
+
+            await Promise.all(addUserArray);
         }
 
         if (!replyMsg) {

--- a/src/Controllers/OtterbrassMessageController.ts
+++ b/src/Controllers/OtterbrassMessageController.ts
@@ -496,7 +496,7 @@ export class OtterBrassMessageController implements MessageControllerInterface {
             await this.channelControllerInstance.createReply(BotMessages.INCORRECT_MESSAGE, activity);
         }
         else {
-            // User was successfully added.
+            // User was successfully removed.
             await this.channelControllerInstance.createReply(replyMsg, activity);
         }
     }

--- a/src/Dao/UserDao.ts
+++ b/src/Dao/UserDao.ts
@@ -31,6 +31,7 @@ export class UserDao {
 
             pool.close();
             sql.close();
+            AppInsights.instance.logTrace(`[addUser] ${JSON.stringify(user)}`);
         } catch (error) {
             AppInsights.instance.logException(JSON.stringify(error));
             throw error;
@@ -52,6 +53,7 @@ export class UserDao {
 
             pool.close();
             sql.close();
+            AppInsights.instance.logTrace(`[removeUser] ${JSON.stringify(user)}`);
         } catch (error) {
             AppInsights.instance.logException(JSON.stringify(error));
             throw error;
@@ -92,6 +94,7 @@ export class UserDao {
                     sql.close();
 
                     result.set(user, data.output.result);
+                    AppInsights.instance.logTrace(`[setOofStatus] ${JSON.stringify(user)}`);
                 }
             }
         } catch (error) {
@@ -125,6 +128,8 @@ export class UserDao {
 
             pool.close();
             sql.close();
+            AppInsights.instance.logTrace(`[getOofUsers] ${JSON.stringify(channel)}`);
+
         } catch (error) {
             AppInsights.instance.logException(JSON.stringify(error));
             throw error;
@@ -150,6 +155,7 @@ export class UserDao {
 
             pool.close();
             sql.close();
+            AppInsights.instance.logTrace(`[addRandom] ${JSON.stringify(user)}`);
         } catch (error) {
             AppInsights.instance.logException(JSON.stringify(error));
             throw error;
@@ -173,6 +179,7 @@ export class UserDao {
 
             pool.close();
             sql.close();
+            AppInsights.instance.logTrace(`[removeRandom] ${JSON.stringify(user)}`);
         } catch (error) {
             AppInsights.instance.logException(JSON.stringify(error));
             throw error;

--- a/src/bot.ts
+++ b/src/bot.ts
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 
 import { ActivityHandler, MessageFactory } from 'botbuilder';
+import { AppInsights } from './Common/AppInsights';
 import { MessageController} from './Controllers/MessageController'
 
 export class EchoBot extends ActivityHandler {
@@ -12,10 +13,14 @@ export class EchoBot extends ActivityHandler {
         this._messageController = new MessageController();
         // See https://aka.ms/about-bot-activity-message to learn more about the message and other activity types.
         this.onMessage(async (context, next) => {
-
-            await this._messageController.parse(context)
-            // By calling next() you ensure that the next BotHandler is run.
-            await next();
+            
+            try {
+                await this._messageController.parse(context)
+                // By calling next() you ensure that the next BotHandler is run.
+                await next();
+            } catch(error) {
+                AppInsights.instance.logException(JSON.stringify(error));
+            }
         });
 
         this.onMembersAdded(async (context, next) => {


### PR DESCRIPTION
This PR does several things but mostly resolves a lot of issues when adding and removing users. 
- on removeUser: verifies that the if the user is the removed from the last channel it also gets removed from the users table
- on removeUserOOF: it was not removing users before because there was an issue on the conditio on line 55. ChannelsOtterBrassUser_internal_id

It also fixes several TODOs pending from migration. After this otterbrass seems stable but still some replies are failing due to #3