### PR TITLE
Removing singleton from controllers

### DIFF
--- a/src/Controllers/CommonMessageController.ts
+++ b/src/Controllers/CommonMessageController.ts
@@ -1,6 +1,6 @@
 import { ChannelControllersInterface } from '../Interfaces/ChannelControllersInterface';
 import { TeamsChannelController } from './TeamsChannelController';
-import { Activity, Entity, Mention, ChannelAccount, TurnContext } from 'botbuilder';
+import { Activity, Mention, ChannelAccount, TurnContext } from 'botbuilder';
 import { Channel } from '../Models/Channel';
 import { User } from '../Models/User';
 import { Utilities } from '../Common/Utilities';

--- a/src/Controllers/CommonMessageController.ts
+++ b/src/Controllers/CommonMessageController.ts
@@ -11,31 +11,13 @@ import { ReviewDao } from '../Dao/ReviewDao';
 import { Constants } from '../Common/Constants';
 
 export class CommonMessagesController {
-    private static _myLazyController: CommonMessagesController;
     private context: TurnContext;
     private channelControllerInstance: ChannelControllersInterface;
 
-    private constructor(context: TurnContext) {
+    public constructor(context: TurnContext) {
         this.context = context;
-        this.channelControllerInstance = TeamsChannelController.instance(this.context);
+        this.channelControllerInstance = new TeamsChannelController(this.context);
     }
-
-    private static readonly myLazyController = (context: TurnContext) => {
-        if (!CommonMessagesController._myLazyController) {
-            CommonMessagesController._myLazyController = new CommonMessagesController(context);
-        }
-
-        CommonMessagesController._myLazyController.context = context;
-        return CommonMessagesController._myLazyController;
-    };
-
-    /**
-     * Gets a singleton instance of the CommonMessagesController class.
-     */
-    public static instance(context: TurnContext): CommonMessagesController {
-        return CommonMessagesController.myLazyController(context);
-    }
-
 
     public async addUser(activity: Activity): Promise<void> {
         if (!activity) {

--- a/src/Controllers/MessageController.ts
+++ b/src/Controllers/MessageController.ts
@@ -21,14 +21,14 @@ export class MessageController {
         }
 
         const activity = context.activity;
-        const _messageController: MessageControllerInterface = OtterBrassMessageController.instance(context);
-        const _channelController: ChannelControllersInterface = TeamsChannelController.instance(context);
+        const _messageController: MessageControllerInterface = new OtterBrassMessageController(context);
+        const _channelController: ChannelControllersInterface = new TeamsChannelController(context);
 
         switch (InstructionsParser.parse(activity.text))
         {
             case EnumInstructions.AddUser:
                 {
-                    _messageController.addUser(activity);
+                    await _messageController.addUser(activity);
                     break;
                 }
             case EnumInstructions.NextInLine:

--- a/src/Controllers/OtterbrassMessageController.ts
+++ b/src/Controllers/OtterbrassMessageController.ts
@@ -18,34 +18,17 @@ import { AppInsights } from '../Common/AppInsights';
 
 export class OtterBrassMessageController implements MessageControllerInterface {
 
-    private static _myLazyController: OtterBrassMessageController;
     private context: TurnContext;
     private channelControllerInstance: ChannelControllersInterface;
     private _commonMessageController: CommonMessagesController;
 
-    private static readonly myLazyController = (context: TurnContext) => {
-        if (!OtterBrassMessageController._myLazyController) {
-            OtterBrassMessageController._myLazyController = new OtterBrassMessageController(context);
-        }
-
-        OtterBrassMessageController._myLazyController.context = context;
-        return OtterBrassMessageController._myLazyController;
-    }
-
     /**
      * Initializes a new instance of the <see cref="OtterBrassMessageController"/> class.
      */
-    private constructor(context: TurnContext) {
+    public constructor(context: TurnContext) {
         this.context = context;
-        this.channelControllerInstance = TeamsChannelController.instance(this.context);
-        this._commonMessageController = CommonMessagesController.instance(this.context);
-    }
-
-    /**
-     * Gets a singleton instance of the HttpController class.
-     */
-    public static instance(context: TurnContext): MessageControllerInterface {
-        return OtterBrassMessageController.myLazyController(context);
+        this.channelControllerInstance = new  TeamsChannelController(this.context);
+        this._commonMessageController = new CommonMessagesController(this.context);
     }
 
     /**

--- a/src/Controllers/TeamsChannelController.ts
+++ b/src/Controllers/TeamsChannelController.ts
@@ -5,32 +5,14 @@ import { Utilities } from '../Common/Utilities';
 
 export class TeamsChannelController implements ChannelControllersInterface
 {
-    private static _myLazyController: TeamsChannelController;
     private context: TurnContext;
-
-    private static readonly myLazyController = (context: TurnContext) => {
-        if (!TeamsChannelController._myLazyController) {
-            TeamsChannelController._myLazyController = new TeamsChannelController(context);
-        }
-
-        TeamsChannelController._myLazyController.context = context;
-        return TeamsChannelController._myLazyController;
-    }
 
     /**
      * Initializes a new instance of the <see cref="TeamsChannelController"/> class.
      */
-    private constructor(context: TurnContext)
+    public constructor(context: TurnContext)
     {
         this.context = context
-    }
-
-    /**
-     * Gets a singleton instance of the HttpController class.
-     */
-    public static instance(context: TurnContext): ChannelControllersInterface
-    {
-        return TeamsChannelController.myLazyController(context);
     }
 
     /**


### PR DESCRIPTION
It seems that the context expires after a turn
https://docs.microsoft.com/en-us/azure/bot-service/bot-builder-basics?view=azure-bot-service-4.0

So a singleton is not the best idea for the controllers as it will reuse the context that might already been expired.

I'm also fixing a bug where we were not awaiting all the operations on MessageController: addUser method, this is a requirement otherwise the context will expire: From documentation

"Be sure to await any activity calls so the primary thread will wait on the generated activity before finishing its processing and disposing of the turn context"

fixes #30 