### PR TITLE
Removing duplicates from user and channel db

### DIFF
--- a/deploymentScripts/DbScripts/v1.6/RunAfterAll.sql
+++ b/deploymentScripts/DbScripts/v1.6/RunAfterAll.sql
@@ -1,0 +1,94 @@
+-- Fixing an issue with data duplication on primary tables due to
+-- a missing contrainst on two tables, This scripts adds the constrains
+-- but it first clean data that do not complain with it.
+
+
+BEGIN TRANSACTION
+
+    -- Removing duplicated users
+
+    DECLARE @duplicatedIdTable TABLE (Id   NVARCHAR(240));
+    DECLARE @duplicatedIdLooper NVARCHAR(240);
+
+    INSERT INTO @duplicatedIdTable(Id)
+        SELECT Id FROM (
+                SELECT COUNT(Id) as total, Id
+                FROM [dbo].[OtterBrassUser]
+                GROUP BY Id
+        ) result
+        WHERE result.total > 1
+
+    -- Loop through ids
+    DECLARE @RowCount INT = (SELECT COUNT(*) FROM @duplicatedIdTable);
+    WHILE @RowCount > 0
+    BEGIN
+          SELECT @duplicatedIdLooper=[Id]
+          FROM @duplicatedIdTable 
+          ORDER BY [Id] DESC OFFSET @RowCount - 1 ROWS FETCH NEXT 1 ROWS ONLY;
+
+          EXEC usp_purgeUser @duplicatedIdLooper
+
+          SET @RowCount -= 1;
+    END
+
+    IF @@ERROR <> 0
+    BEGIN
+        -- Rollback the transaction
+        ROLLBACK
+
+        -- Raise an error and return
+        RAISERROR ('Error while purging duplicated users, cannot continue update', 16, 1)
+        RETURN
+    END
+
+   -- Removing duplicated channelIds
+
+   DECLARE @duplicatedChannelIdTable TABLE (Id   NVARCHAR(240));
+    DECLARE @duplicatedChannelIdLooper NVARCHAR(240);
+
+    INSERT INTO @duplicatedChannelIdTable(Id)
+        SELECT Id FROM (
+                SELECT COUNT(Id) as total, Id
+                FROM [dbo].[Channels]
+                GROUP BY Id
+        ) result
+        WHERE result.total > 1
+
+    -- Loop through ids
+    DECLARE @ChannelRowCount INT = (SELECT COUNT(*) FROM @duplicatedChannelIdTable);
+    WHILE @ChannelRowCount > 0
+    BEGIN
+          SELECT @duplicatedChannelIdLooper=[Id]
+          FROM @duplicatedChannelIdTable 
+          ORDER BY [Id] DESC OFFSET @ChannelRowCount - 1 ROWS FETCH NEXT 1 ROWS ONLY;
+
+          EXEC usp_purgeChannel @duplicatedChannelIdLooper
+
+          SET @ChannelRowCount -= 1;
+    END
+
+    IF @@ERROR <> 0
+    BEGIN
+        -- Rollback the transaction
+        ROLLBACK
+
+        -- Raise an error and return
+        RAISERROR ('Error while purging duplicated channels, cannot continue update', 16, 1)
+        RETURN
+    END
+
+    ALTER TABLE [OtterBrassUser]
+    ALTER COLUMN Id NVARCHAR(440)
+
+    ALTER TABLE [OtterBrassUser]
+    ALTER COLUMN Name NVARCHAR(440)
+
+    ALTER TABLE [Channels]
+    ALTER COLUMN Id NVARCHAR(440)
+
+    ALTER TABLE [OtterBrassUser] 
+    ADD CONSTRAINT UK_UniqueIdConstraint UNIQUE(Id)
+
+    ALTER TABLE [Channels] 
+    ADD CONSTRAINT UK_ChannelsUniqueIdConstraint UNIQUE(Id)
+COMMIT TRANSACTION

--- a/deploymentScripts/DbScripts/v1.6/Version.sql
+++ b/deploymentScripts/DbScripts/v1.6/Version.sql
@@ -1,0 +1,11 @@
+﻿DECLARE @versionTable TABLE (Internal_id  INT);
+
+INSERT INTO @versionTable
+SELECT Internal_Id
+FROM [Version]
+
+UPDATE [Version]
+SET [Version] = 1.6
+WHERE [Internal_Id] IN
+    (SELECT [Internal_Id]
+    FROM @versionTable);

--- a/deploymentScripts/DbScripts/v1.6/usp_RemoveUser.sql
+++ b/deploymentScripts/DbScripts/v1.6/usp_RemoveUser.sql
@@ -1,0 +1,165 @@
+ALTER PROCEDURE usp_RemoveUser
+    @channelId          NVARCHAR(255),   
+    @channelName        NVARCHAR(255),
+    @userId             NVARCHAR(255),
+    @userName           NVARCHAR(255)   
+AS   
+    SET NOCOUNT ON;  
+
+    BEGIN TRANSACTION
+
+    DECLARE @channelInternalTable TABLE (internal_id   INT);
+    DECLARE @channelInternalIdCount INT;
+    DECLARE @channelInternalId INT;
+
+    -- GET THE CHANNEL INTERNAL ID
+
+    SELECT @channelInternalIdCount = COUNT(Internal_id)
+    FROM  [Channels]
+    WHERE [Id] = @channelId
+
+    IF @channelInternalIdCount < 1
+    BEGIN
+       RAISERROR ('Error, channel has not been added', 
+               16, -- Severity
+               1 -- State
+               );  
+    END
+    ELSE
+    BEGIN
+        INSERT INTO @channelInternalTable(Internal_id)
+            SELECT TOP(1)Internal_id
+            FROM  [Channels]
+            WHERE [Id] = @channelId 
+    END
+
+    IF @@ERROR <> 0
+    BEGIN
+        -- Rollback the transaction
+        ROLLBACK
+
+        -- Raise an error and return
+        RAISERROR ('Error, channel has not been added', 16, 1)
+        RETURN
+    END
+
+    SELECT TOP(1) @channelInternalId =  Internal_id
+    FROM  @channelInternalTable
+
+
+    -- GET THE USER INTERNAL ID
+    DECLARE @userInternalIdTable TABLE (internal_id   INT);
+    DECLARE @userInternalIdCount INT;
+    DECLARE @userInternalId INT;
+
+    SELECT @userInternalIdCount = COUNT(cobu.User_internal_id)
+    FROM[Channels] c
+    INNER JOIN [ChannelsOtterBrassUser] cobu
+    ON c.Internal_id = cobu.Channel_internal_id
+    INNER JOIN [OtterBrassUser] obu
+    ON cobu.User_Internal_id = obu.Internal_Id
+    WHERE c.id = @channelId
+    AND obu.id = @userId
+
+    IF @userInternalIdCount < 1
+    BEGIN
+        RAISERROR ('Error, user has not been added', 16, 1)
+    END
+    ELSE
+    BEGIN
+        INSERT INTO @userInternalIdTable(Internal_id)
+            SELECT TOP(1) obu.Internal_id
+            FROM[Channels] c
+            INNER JOIN [ChannelsOtterBrassUser] cobu
+            ON c.Internal_id = cobu.Channel_internal_id
+            INNER JOIN [OtterBrassUser] obu
+            ON cobu.User_Internal_id = obu.Internal_Id
+            WHERE c.id = @channelId
+            AND obu.id = @userId
+    END
+
+    IF @@ERROR <> 0
+    BEGIN
+        -- Rollback the transaction
+        ROLLBACK
+
+        -- Raise an error and return
+        RAISERROR ('Error, user has not been added', 16, 1)
+        RETURN
+    END
+
+    SELECT TOP(1) @userInternalId =  Internal_id
+    FROM  @userInternalIdTable
+
+    -- REMOVING THE USER-CHANNEL RELATION
+    DECLARE @userChannelsInternalTable TABLE (Internal_id  INT);
+    DECLARE @userChannelsInternalIdCount INT;
+    DECLARE @userChannelsInternalId INT;
+    DECLARE @totalNumberOfChannelsAdded INT;
+
+    SELECT @userChannelsInternalIdCount = COUNT(Internal_id)
+    FROM [ChannelsOtterBrassUser]
+    WHERE [User_internal_id] = @userInternalId
+    AND   [Channel_internal_id] = @channelInternalId
+
+    IF @userChannelsInternalIdCount < 1
+    BEGIN
+        RAISERROR ('Error, specified user has not been added on that channel', 16, 1)
+    END
+    ELSE
+    BEGIN
+
+    INSERT INTO @userChannelsInternalTable(Internal_id)
+          SELECT TOP(1) Internal_id
+          FROM [ChannelsOtterBrassUser]
+          WHERE [User_internal_id] = @userInternalId
+          AND   [Channel_internal_id] = @channelInternalId
+
+      EXEC usp_RemoveUserRandom @channelId,@userId
+      EXEC usp_RemoveUserOof @channelId,@userId
+
+      DELETE FROM [UserRanking]
+      WHERE [ChannelsOtterBrassUser_internalId] IN 
+      (SELECT [Internal_id]
+       FROM @userChannelsInternalTable);
+      
+      ALTER TABLE [ChannelsOtterBrassUser] 
+      DROP CONSTRAINT FK_OtterBrassUser;
+      
+      ALTER TABLE [ChannelsOtterBrassUser] 
+      DROP CONSTRAINT FK_Channel;
+      
+      DELETE FROM [ChannelsOtterBrassUser]
+      WHERE [User_internal_id] = @userInternalId
+      AND   [Channel_internal_id] = @channelInternalId
+
+      -- If it is the only/last channel were user exist also drop it from the user table
+      SELECT @totalNumberOfChannelsAdded = COUNT(Internal_id)
+      FROM [ChannelsOtterBrassUser]
+      WHERE [User_internal_id] = @userInternalId
+
+      IF @totalNumberOfChannelsAdded < 1
+      BEGIN
+        DELETE FROM [OtterBrassUser]
+        WHERE [Id] = @userId
+      END
+
+      ALTER TABLE [ChannelsOtterBrassUser] ADD CONSTRAINT FK_OtterBrassUser FOREIGN KEY (User_internal_id) REFERENCES OtterBrassUser(Internal_id);
+      ALTER TABLE [ChannelsOtterBrassUser] ADD CONSTRAINT FK_Channel FOREIGN KEY (Channel_internal_id) REFERENCES Channels(Internal_id);
+
+    END
+
+    IF @@ERROR <> 0
+    BEGIN
+        -- Rollback the transaction
+        ROLLBACK
+
+        -- Raise an error and return
+        RAISERROR ('Error in while deleting the user.', 16, 1)
+        RETURN
+    END
+    
+    
+
+    COMMIT
+GO

--- a/deploymentScripts/DbScripts/v1.6/usp_purgeChannel.sql
+++ b/deploymentScripts/DbScripts/v1.6/usp_purgeChannel.sql
@@ -1,0 +1,169 @@
+-- DUE TO THE DESTRUCTIVE NATURE OF THIS SCRIPT FIRST THING WE NEED TO DO IS TO DISSASOCIATE ALL THE USERS, as ALL THE INFORMATION LINKED TO CHANNEL
+-- WILL BE DELETED.
+
+CREATE PROCEDURE usp_purgeChannel
+    @channelId             NVARCHAR(255)
+AS   
+    SET NOCOUNT ON;  
+
+    BEGIN TRANSACTION
+
+    -- GET THE CHANNEL INTERNAL ID
+    DECLARE @channelInternalIdTable TABLE (Internal_id   INT);
+    DECLARE @channelInternalIdCount INT;
+
+    SELECT @channelInternalIdCount = COUNT(c.id)
+    FROM[Channels] c
+    WHERE c.id = @channelId
+
+    IF @channelInternalIdCount < 1
+    BEGIN
+        RAISERROR ('Error, Channel is not present in the channel table so I cannot force delete them', 16, 1)
+    END
+    ELSE
+    BEGIN
+        INSERT INTO @channelInternalIdTable(Internal_id)
+            SELECT c.Internal_id
+            FROM[Channels] c
+            WHERE c.id = @channelId
+    END
+
+     IF @@ERROR <> 0
+    BEGIN
+        -- Rollback the transaction
+        ROLLBACK
+
+        -- Raise an error and return
+        RAISERROR ('Error, channel was not deleted', 16, 1)
+        RETURN
+    END
+
+        -- GET ALL THE USERS
+    DECLARE @usersIdNameTable  TABLE (Id  NVARCHAR(455), Name NVARCHAR(455));
+    DECLARE @usersIdNameTableCount INT;
+
+    SELECT @usersIdNameTableCount = COUNT(Internal_id)
+    FROM [ChannelsOtterBrassUser]
+    WHERE [Channel_internal_id] IN (
+        SELECT [Internal_id]
+        FROM @channelInternalIdTable);
+
+    IF @usersIdNameTableCount < 1
+    BEGIN
+        RAISERROR ('Error, Channel is not present in the user-channel relation table so I cannot force delete them', 16, 1)
+    END
+    ELSE
+    BEGIN
+
+    INSERT INTO @usersIdNameTable(Id, Name)
+          SELECT obu.Id, obu.Name
+          FROM [OtterBrassUser] obu
+          INNER JOIN [ChannelsOtterBrassUser] cobu
+          ON cobu.[User_internal_id] = obu.[Internal_id]
+          WHERE cobu.[Channel_internal_id] IN (
+        SELECT [Internal_Id]
+        FROM @channelInternalIdTable);
+    END
+
+    -- LOOP THROUGH THE CHANNELS FOUND
+      DECLARE @OuterRowCount INT = (SELECT COUNT(*) FROM @channelInternalIdTable);
+      DECLARE @OuterChannelIdLooper NVARCHAR(455);
+      DECLARE @OuterChannelNameLooper NVARCHAR(455);
+      WHILE @OuterRowCount > 0 BEGIN
+          SELECT @OuterChannelIdLooper=[Id], @OuterChannelNameLooper=[Name]
+          FROM [Channels] c
+          WHERE c.[Internal_id] IN (
+            SELECT [Internal_id]
+            FROM @channelInternalIdTable)
+          ORDER BY [Internal_id] DESC OFFSET @OuterRowCount - 1 ROWS FETCH NEXT 1 ROWS ONLY;
+
+                -- Then loop through the users associated to the channel
+
+                  DECLARE @RowCount INT = (SELECT COUNT(*) FROM @usersIdNameTable);
+                  DECLARE @UserIdLooper NVARCHAR(455);
+                  DECLARE @userNameLooper NVARCHAR (455);
+
+                  WHILE @RowCount > 0 BEGIN
+                      SELECT @UserIdLooper=[Id], @userNameLooper=[Name]
+                      FROM @usersIdNameTable 
+                      ORDER BY [Id] DESC OFFSET @RowCount - 1 ROWS FETCH NEXT 1 ROWS ONLY;
+
+                        EXEC usp_RemoveUser @OuterChannelIdLooper,@OuterChannelNameLooper,@UserIdLooper,@userNameLooper
+
+                      SET @RowCount -= 1;
+                  END
+          SET @OuterRowCount -= 1;
+      END
+
+    IF @@ERROR <> 0
+    BEGIN
+        -- Rollback the transaction
+        ROLLBACK
+
+        -- Raise an error and return
+        RAISERROR ('Error, channel was not deleted', 16, 1)
+        RETURN
+    END
+
+
+    -- REMOVING THE USER-CHANNEL RELATION
+    DECLARE @userChannelsInternalTable TABLE (Internal_id  INT);
+    DECLARE @userChannelsInternalIdCount INT;
+    DECLARE @userChannelsInternalId INT;
+    DECLARE @totalNumberOfChannelsAdded INT;
+
+    SELECT @userChannelsInternalIdCount = COUNT(Internal_id)
+    FROM [ChannelsOtterBrassUser]
+    WHERE [Channel_internal_id] IN (
+        SELECT [Internal_Id]
+        FROM @channelInternalIdTable);
+
+    IF @userChannelsInternalIdCount < 1
+    BEGIN
+        RAISERROR ('Error, Channel is not present in the user table so I cannot force delete them', 16, 1)
+    END
+    ELSE
+    BEGIN
+
+      ALTER TABLE [ChannelsOtterBrassUser] 
+      DROP CONSTRAINT FK_OtterBrassUser;
+      
+      ALTER TABLE [ChannelsOtterBrassUser] 
+      DROP CONSTRAINT FK_Channel;
+      
+      DELETE FROM [ChannelsOtterBrassUser]
+      WHERE [Channel_internal_id] IN (
+        SELECT [Internal_Id]
+        FROM @channelInternalIdTable);
+
+      ALTER TABLE [ChannelsOtterBrassUser] ADD CONSTRAINT FK_OtterBrassUser FOREIGN KEY (User_internal_id) REFERENCES OtterBrassUser(Internal_id);
+      ALTER TABLE [ChannelsOtterBrassUser] ADD CONSTRAINT FK_Channel FOREIGN KEY (Channel_internal_id) REFERENCES Channels(Internal_id);
+
+    END
+
+    IF @@ERROR <> 0
+    BEGIN
+        -- Rollback the transaction
+        ROLLBACK
+
+        -- Raise an error and return
+        RAISERROR ('Error in while deleting the user-channel relation.', 16, 1)
+        RETURN
+    END
+
+    -- DELETE THE CHANNEL
+    DELETE FROM [Channels]
+    WHERE id = @channelId
+
+        IF @@ERROR <> 0
+    BEGIN
+        -- Rollback the transaction
+        ROLLBACK
+
+        -- Raise an error and return
+        RAISERROR ('Error in while deleting the channel.', 16, 1)
+        RETURN
+    END
+
+    COMMIT TRANSACTION
+GO

--- a/deploymentScripts/DbScripts/v1.6/usp_purgeUser.sql
+++ b/deploymentScripts/DbScripts/v1.6/usp_purgeUser.sql
@@ -1,0 +1,137 @@
+-- Forces delete (purges) data associated to a specific user 
+-- CAUTION DELETES DATA FROM ALL CHANNELS
+
+CREATE PROCEDURE usp_purgeUser
+    @userId             NVARCHAR(255)
+AS   
+    SET NOCOUNT ON;  
+
+    BEGIN TRANSACTION
+
+    -- GET THE USER INTERNAL ID
+    DECLARE @userInternalIdTable TABLE (internal_id   INT);
+    DECLARE @userInternalIdCount INT;
+
+    SELECT @userInternalIdCount = COUNT(cobu.User_internal_id)
+    FROM[Channels] c
+    INNER JOIN [ChannelsOtterBrassUser] cobu
+    ON c.Internal_id = cobu.Channel_internal_id
+    INNER JOIN [OtterBrassUser] obu
+    ON cobu.User_Internal_id = obu.Internal_Id
+    AND obu.id = @userId
+
+    IF @userInternalIdCount < 1
+    BEGIN
+        RAISERROR ('Error, User is not present in the user table so I cannot force delete them', 16, 1)
+    END
+    ELSE
+    BEGIN
+        INSERT INTO @userInternalIdTable(Internal_id)
+            SELECT obu.Internal_id
+            FROM[Channels] c
+            INNER JOIN [ChannelsOtterBrassUser] cobu
+            ON c.Internal_id = cobu.Channel_internal_id
+            INNER JOIN [OtterBrassUser] obu
+            ON cobu.User_Internal_id = obu.Internal_Id
+            WHERE obu.id = @userId
+    END
+
+     IF @@ERROR <> 0
+    BEGIN
+        -- Rollback the transaction
+        ROLLBACK
+
+        -- Raise an error and return
+        RAISERROR ('Error, user was not deleted', 16, 1)
+        RETURN
+    END
+
+
+    -- REMOVING THE USER-CHANNEL RELATION
+    DECLARE @userChannelsInternalTable TABLE (Internal_id  INT);
+    DECLARE @userChannelsInternalIdCount INT;
+    DECLARE @userChannelsInternalId INT;
+    DECLARE @totalNumberOfChannelsAdded INT;
+
+    SELECT @userChannelsInternalIdCount = COUNT(Internal_id)
+    FROM [ChannelsOtterBrassUser]
+    WHERE [User_internal_id] IN (
+        SELECT [Internal_Id]
+        FROM @userInternalIdTable);
+
+    IF @userChannelsInternalIdCount < 1
+    BEGIN
+        RAISERROR ('Error, User is not present in the user table so I cannot force delete them', 16, 1)
+    END
+    ELSE
+    BEGIN
+
+    INSERT INTO @userChannelsInternalTable(Internal_id)
+          SELECT Internal_id
+          FROM [ChannelsOtterBrassUser]
+          WHERE [User_internal_id] IN (
+        SELECT [Internal_Id]
+        FROM @userInternalIdTable);
+
+    
+    -- Loop through channels
+      DECLARE @RowCount INT = (SELECT COUNT(*) FROM @userChannelsInternalTable);
+      DECLARE @ChannelInternalIdLooper INT;
+
+      WHILE @RowCount > 0 BEGIN
+          SELECT @ChannelInternalIdLooper=[Internal_id]
+          FROM @userChannelsInternalTable 
+          ORDER BY [Internal_id] DESC OFFSET @RowCount - 1 ROWS FETCH NEXT 1 ROWS ONLY;
+
+          EXEC usp_RemoveUserRandom @ChannelInternalIdLooper,@userId
+          EXEC usp_RemoveUserOof @ChannelInternalIdLooper,@userId
+
+          SET @RowCount -= 1;
+      END
+
+      DELETE FROM [UserRanking]
+      WHERE [ChannelsOtterBrassUser_internalId] IN 
+      (SELECT [Internal_id]
+       FROM @userChannelsInternalTable);
+      
+      ALTER TABLE [ChannelsOtterBrassUser] 
+      DROP CONSTRAINT FK_OtterBrassUser;
+      
+      ALTER TABLE [ChannelsOtterBrassUser] 
+      DROP CONSTRAINT FK_Channel;
+      
+      DELETE FROM [ChannelsOtterBrassUser]
+      WHERE [User_internal_id] IN (
+        SELECT [Internal_Id]
+        FROM @userInternalIdTable);
+
+      -- If it is the only/last channel were user exist also drop it from the user table
+      SELECT @totalNumberOfChannelsAdded = COUNT(Internal_id)
+      FROM [ChannelsOtterBrassUser]
+      WHERE [User_internal_id] IN (
+        SELECT [Internal_Id]
+        FROM @userInternalIdTable);
+
+      IF @totalNumberOfChannelsAdded < 1
+      BEGIN
+        DELETE FROM [OtterBrassUser]
+        WHERE [Id] = @userId
+      END
+
+      ALTER TABLE [ChannelsOtterBrassUser] ADD CONSTRAINT FK_OtterBrassUser FOREIGN KEY (User_internal_id) REFERENCES OtterBrassUser(Internal_id);
+      ALTER TABLE [ChannelsOtterBrassUser] ADD CONSTRAINT FK_Channel FOREIGN KEY (Channel_internal_id) REFERENCES Channels(Internal_id);
+
+    END
+
+    IF @@ERROR <> 0
+    BEGIN
+        -- Rollback the transaction
+        ROLLBACK
+
+        -- Raise an error and return
+        RAISERROR ('Error in while deleting the user.', 16, 1)
+        RETURN
+    END
+
+    COMMIT
+GO


### PR DESCRIPTION
Adding a constraint to the DB:
- Channels Ids (Not internal_id) should be unique
- User Ids(Not internal_ids) should be unique

Database needs to be cleaned first before adding these two constraints, so adding `usp_purgeChannel` and `usp_purgeUser`